### PR TITLE
doc: add vision and mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # bootstrap
 Foundation Bootstrap Team
+
+## What's in a name?
+
+As we do not yet have a name for a merged entity we shall refer to merged entity in this document
+as $FOUNDATION
+
+## Mission
+
+$FOUNDATION envisions a future where JavaScript is a sustainable platform for implementing best in
+class experiences in production across all types of workloads.  The $FOUNDATION is committed to
+being a catalyst across the industry making our technological communities productive, sustainable,
+equitable, diverse and inclusive.
+
+## Vision
+
+To enable widespread adoption and help accelerate development of JavaScript and key ecosystem projects
+across connected devices, servers and networks, user agents and runtimes. The $FOUNDATION supports its
+hosted projects through open governance models and social structures that encourage community, skills
+growth, technical contribution, standards engagement, and inclusive participation.
+>>>>>>> doc: add vision and mission

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ as $FOUNDATION.
 ## Mission
 
 $FOUNDATION envisions a future where JavaScript is a sustainable platform for implementing best in
-class experiences in production across all types of workloads.  The $FOUNDATION is committed to
+class experiences in production across all types of workloads. The $FOUNDATION is committed to
 being a catalyst across the industry making our technological communities productive, sustainable,
 equitable, diverse and inclusive.
 

--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ To enable widespread adoption and help accelerate development of JavaScript and 
 across connected devices, servers and networks, user agents and runtimes. The $FOUNDATION supports its
 hosted projects through open governance models and social structures that encourage community, skills
 growth, technical contribution, standards engagement, and inclusive participation.
->>>>>>> doc: add vision and mission

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Foundation Bootstrap Team
 ## What's in a name?
 
 As we do not yet have a name for a merged entity we shall refer to merged entity in this document
-as $FOUNDATION
+as $FOUNDATION.
 
 ## Mission
 


### PR DESCRIPTION
The mission / values statement drafted in the board's merger
subcommittee were used as a baseline for decision making and
direction. This commit captures these in the README of the repo