### PR TITLE
Create expectations for foundation draft

### DIFF
--- a/expectations-of-foundation.md
+++ b/expectations-of-foundation.md
@@ -17,3 +17,4 @@ This document is for the initial phase of work for the Bootstrap team to draft r
 - Earmarking allowed with flexibility in budgeting for concerns and needs of individual projects
 - Value satisfaction: regular feedback from projects
 - Explicit acknowledgement and documention for the ability of projects to leave the foundation
+- Foundation should document a clear process for trademark usage to enable community not-for-profit efforts

--- a/expectations-of-foundation.md
+++ b/expectations-of-foundation.md
@@ -7,7 +7,7 @@ This document is for the initial phase of work for the Bootstrap team to draft r
 - Annual reviews of staff, NPS, board, programs, support services to projects for accountability and incremental improvement
 - The foundation staff, executive director, and board should follow a leadership style that prioritizes and promotes the well-being of the project and those who prioritize and promote a healthy project and ecosystem.
 - Project representation on the Board
-  - Projects could have tiers, only 'platinum' projecs should sit on the Board directly. Other projects would have shared seats(like gold/silver member strcuture)
+  - Community Representation should sit on the Board directly. Projects could share this representation.
   - Community representation on the Board: 1 seat guaranteed for the Cross-Project Community Council and 1 seat for Individual Membership program if and only if threshold requirements have been met(TODO)
   - Each council(CPC and Community Council) should have a given allocation of Board seats. How these are allocated should be defined by each respective council.
 - Board must establish Cross Project Council focused on the specific needs of the member projects

--- a/expectations-of-foundation.md
+++ b/expectations-of-foundation.md
@@ -1,0 +1,20 @@
+# Expectations
+With the intent to merge the Node.js Foundation and JS Foundation being announced, those interested in the continued support of Node.js and JS-related projects are working through expectations and structure for what the potential new foundation could look like. 
+
+This document is for the initial phase of work for the Bootstrap team to draft requirements that overlap with scope of the Board in order to provide an outline and structure for the foundation attuned to the needs of the projects and ecosystem stakeholders who have participated.
+
+- Communicated scope for the foundation and board
+- Annual reviews of staff, NPS, board, programs, support services to projects for accountability and incremental improvement
+- The foundation staff, executive director, and board should follow a "servant leadership" style.
+- Project representation on the Board
+  - Projects could have tiers, only 'platinum' projecs should sit on the Board directly. Other projects would have shared seats(like gold/silver member strcuture)
+  - Community representation on the Board: 1 seat guaranteed for the Cross-Project Community Council and 1 seat for Individual Membership program if and only if threshold requirements have been met(TODO)
+  - Each council(CPC and Community Council) should have a given allocation of Board seats. How these are allocated should be defined by each respective council.
+- Board must establish Cross Project Council focused on the specific needs of the member projects
+  - Allow projects to self-organize amongst themselves. Processes are defined and driven by project e.g. CPC is not structured by the Board
+  - CPC should be co-chaired by the Executive Director of the foundation
+- Non-corporate member representation in budget/finance subcommittee
+- Projects values should drive foundation focus and priority
+- No "pay to play" in technical participation
+- Earmarking allowed with flexibility in budgeting for concerns and needs of individual projects
+- Value satisfaction: regular feedback from projects

--- a/expectations-of-foundation.md
+++ b/expectations-of-foundation.md
@@ -5,7 +5,7 @@ This document is for the initial phase of work for the Bootstrap team to draft r
 
 - Communicated scope for the foundation and board
 - Annual reviews of staff, NPS, board, programs, support services to projects for accountability and incremental improvement
-- The foundation staff, executive director, and board should follow a "servant leadership" style.
+- The foundation staff, executive director, and board should follow a leadership style that prioritizes and promotes the well-being of the project and those who prioritize and promote a healthy project and ecosystem.
 - Project representation on the Board
   - Projects could have tiers, only 'platinum' projecs should sit on the Board directly. Other projects would have shared seats(like gold/silver member strcuture)
   - Community representation on the Board: 1 seat guaranteed for the Cross-Project Community Council and 1 seat for Individual Membership program if and only if threshold requirements have been met(TODO)

--- a/expectations-of-foundation.md
+++ b/expectations-of-foundation.md
@@ -16,3 +16,4 @@ This document is for the initial phase of work for the Bootstrap team to draft r
 - No "pay to play" in technical participation
 - Earmarking allowed with flexibility in budgeting for concerns and needs of individual projects
 - Value satisfaction: regular feedback from projects
+- Explicit acknowledgement and documention for the ability of projects to leave the foundation

--- a/expectations-of-foundation.md
+++ b/expectations-of-foundation.md
@@ -8,11 +8,9 @@ This document is for the initial phase of work for the Bootstrap team to draft r
 - The foundation staff, executive director, and board should follow a leadership style that prioritizes and promotes the well-being of the project and those who prioritize and promote a healthy project and ecosystem.
 - Project representation on the Board
   - Community Representation should sit on the Board directly. Projects could share this representation.
-  - Community representation on the Board: 1 seat guaranteed for the Cross-Project Community Council and 1 seat for Individual Membership program if and only if threshold requirements have been met(TODO)
-  - Each council(CPC and Community Council) should have a given allocation of Board seats. How these are allocated should be defined by each respective council.
+  - Community representation on the Board: 3 seats guaranteed for community representation
 - Board must establish Cross Project Council focused on the specific needs of the member projects
   - Allow projects to self-organize amongst themselves. Processes are defined and driven by project e.g. CPC is not structured by the Board
-  - CPC should be co-chaired by the Executive Director of the foundation
 - Non-corporate member representation in budget/finance subcommittee
 - Projects values should drive foundation focus and priority
 - No "pay to play" in technical participation


### PR DESCRIPTION
With the intent to merge the Node.js Foundation and JS Foundation being announced, those interested in the continued support of Node.js and JS-related projects are working through expectations and structure for what the potential new foundation could look like. 

This document is for the initial phase of work for the Bootstrap team to draft requirements that overlap with scope of the Board in order to provide an outline and structure for the foundation attuned to the needs of the projects and ecosystem stakeholders who have participated.

If lines are removed from this document, it may not be because they have been -1ed for application in the design of the new foundation but may in fact just be outside of the scope of this particular document. 

This document is intended to be delivered to the Node.js Foundation and JSF Boards in order to outline the recommended structure of the foundation and to inform the Bylaws first draft.