### PR TITLE
proposal: STANDARDS_OUTREACH meetings effort

### DIFF
--- a/proposals/littledan-STANDARDS_OUTREACH/README.md
+++ b/proposals/littledan-STANDARDS_OUTREACH/README.md
@@ -1,0 +1,47 @@
+# JavaScript Outreach Groups
+>  Stage 0
+
+## Champion
+
+Daniel Ehrenberg (@littledan)
+
+## Description
+
+[JS Outreach Groups](https://github.com/littledan/js-outreach-groups)
+is an effort to have regular calls with various segments of the
+JavaScript community, to consult with them on emerging standards.
+We're starting with TC39 topics, but I imagine it could be useful for
+other standards as well.
+
+## Required Resources
+
+Resources the Foundation could provide to help:
+- A neutral home to base this outreach from, which participants can trust. It's awkward to have this as a personal repository.
+- Access to attend standards committee meetings for people who are heavily involved in the efforts ("invited expert" can get awkward).
+
+Work involved in this effort includes:
+- Identifying constituencies who would have relevant feedback in standards bodies which isn't reaching those standards bodies; calling them up, comvincing them to discuss
+- Running the meetings, setting agendas, taking notes, publishing the notes
+- Going to standards bodies and reporting the feedback of these groups, so that it's taken into account
+
+## Who would be responsible?
+
+I'm not sure; I'd like to not be the only person responsible for this. That's why I'd like to work with the Foundation.
+
+## How would success be measured?
+
+These are squishy metrics, but:
+- Standards make better and faster decisions based on feedback from ecosystem stakeholders.
+- Key ecosystem stakeholders are better informed about the developments in standards.
+
+## Why this proposal is important
+
+JavaScript and Web standards will be better if they can take feedback from developers into account!
+
+## Unresolved Question
+
+Will we be able to have the impact we want it to?
+
+## What is necessary to complete this proposal
+
+The MVP here would be to just be able to say that this is a Foundation effort, and publish the notes in a place that's inside of a Foundation-related organization. Meetings are already happening.


### PR DESCRIPTION
 [JS Outreach Groups](https://github.com/littledan/js-outreach-groups)
 is an effort to have regular calls with various segments of the
 JavaScript community, to consult with them on emerging standards.
 We're starting with TC39 topics, but I imagine it could be useful for
 other standards as well.