### PR TITLE
proposal: Community Board Representation Stage 1

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -11,6 +11,7 @@ Anyone may submit an idea for a policy or program following the [staging process
 * [Expectations](./stage-1/EXPECTATIONS)
 * [Project Progression](./stage-1/PROJECT_PROGRESSION)
 * [CPC Charter](./stage-1/CPC_CHARTER)
+* [Community Board representation](./stage-1/community-board-represenation)
 
 ## Stage 2
 

--- a/proposals/stage-0/stage-1/community-board-representation/README.md
+++ b/proposals/stage-0/stage-1/community-board-representation/README.md
@@ -1,0 +1,64 @@
+# Community Board Representation
+>  Stage 1
+
+## Champion
+
+[Myles Borins](https://github.com/MylesBorins)
+
+## Description
+
+### What exists today
+
+Currently the Node.js foundation has up to 3 community board seats:
+
+* 1 board seat for TSC
+* 1 board seat for Community Committee
+* 1 board seat for Individual Membership Program
+
+There are some limitations on these seats as noted in [Section 4.3](https://github.com/nodejs/board/blob/master/by-laws.md#section-43-nomination-election-and-term-of-office-of-directors),
+specifically that:
+
+4.3 d) There must be 3 platinum directors for the individual membership theo elect a board member
+
+4.3 e) There must be 2 platinum directors for the TSC or CommComm to elect a board member
+
+### Proposal for $FOUNDATION
+
+There would be up to 3 community board seats:
+
+* 1 board seat for CPC
+* 1 floating board seat to be delegated by CPC
+  - delegated on an annual basis and approved by Board
+* 1 board seat for the individual membership program
+
+Similar to the current bylaws there would be some limitations that would activate seats:
+
+* CPC would always have a board seat independent of platinum membership
+* There must be 2 platinum directors to activate the floating board seat
+* There must be 3 platinum directors and 2k individual members to activate the individual board member seat
+
+These limitations allow for representation to scale with the growth of the foundation while also ensuring that there
+will always be community representation.
+
+## Who would be responsible?
+
+This would be owned by both the board and the CPC
+
+## Why this proposal is important
+
+Community representation is extremely important to the success of the foundation ensuring the board has insight
+into the community and vice versa.
+
+## Unresolved Question
+
+* Will there be an individual membership program?
+* Is the community ok with the proposed allocation
+* Is the community ok with 1 of the seats only activating with 2k members
+* Is the board ok with the proposed allocation and limitations
+
+## What is necessary to complete this proposal
+
+* Community consensus
+* Board Sign off
+* Implemented in CPC Charter
+* Implemented in $FOUNDATION bylaws


### PR DESCRIPTION
TL;DR

* 1 CPC board seat
* 1 floating board seat
  - allocated by CPC annually
  - Requires 2 Platinum members to activate
* 1 Individual Membership board seat
  - Requires 3 Platinum members and 2k Individual Members to activate

I believe the README.md has everything necessary to reach
consensus on this, thus going for stage one. It will need to be
implemented in the CPC Charter and Foundation Bylaws